### PR TITLE
Use TLS instead of SSL

### DIFF
--- a/lib/mercadopago/request.rb
+++ b/lib/mercadopago/request.rb
@@ -11,7 +11,7 @@ module MercadoPago
     #
     # This URL is the base for all API calls.
     #
-    MERCADOPAGO_URL = 'https://api.mercadolibre.com'
+    MERCADOPAGO_URL = 'https://api.mercadopago.com'
 
     #
     # Makes a POST request to a MercadoPago API.

--- a/lib/mercadopago/request.rb
+++ b/lib/mercadopago/request.rb
@@ -14,7 +14,7 @@ module MercadoPago
     MERCADOPAGO_URL = 'https://api.mercadolibre.com'
 
     #
-    # Makes a POST request to a MercaPago API.
+    # Makes a POST request to a MercadoPago API.
     #
     # - path: the path of the API to be called.
     # - payload: the data to be trasmitted to the API.
@@ -26,7 +26,7 @@ module MercadoPago
     end
 
     #
-    # Makes a GET request to a MercaPago API.
+    # Makes a GET request to a MercadoPago API.
     #
     # - path: the path of the API to be called, including any query string parameters.
     # - headers: the headers to be transmitted over the HTTP request.
@@ -46,7 +46,7 @@ module MercadoPago
     def self.make_request(type, path, payload = nil, headers = {})
       args = [type, MERCADOPAGO_URL, path, payload, headers].compact
 
-      connection = Faraday.new(MERCADOPAGO_URL, ssl: { version: :SSLv3 })
+      connection = Faraday.new(MERCADOPAGO_URL, ssl: { version: :TLSv1_2 })
 
       response = connection.send(type) do |req|
         req.url path

--- a/test/test_mercado_pago.rb
+++ b/test/test_mercado_pago.rb
@@ -113,11 +113,11 @@ class TestMercadoPago < MiniTest::Unit::TestCase
 
   def test_that_client_can_search
     mp_client = MercadoPago::Client.new(CREDENTIALS[:client_id], CREDENTIALS[:client_secret])
-    response = mp_client.search(status: :pending)
+    response = mp_client.search(status: :refunded)
 
     assert response.has_key?('results')
 
-    external_reference = 'OPERATION-ID-1234'
+    external_reference = '55723'
     response = mp_client.search(external_reference: external_reference)
     results = response['results']
 


### PR DESCRIPTION
Hi! 

As MercadoPago is dropping support for SSLv3, [starting March 24th](https://developers.mercadopago.com/), this PR changes the SSL version for HTTP requests from `SSLv3` to `TLSv1_2`, which is possibly the [best alternative](https://www.ssllabs.com/ssltest/analyze.html?d=api.mercadolibre.com&hideResults=on). 

Please check it out, thanks! 